### PR TITLE
Convert `var_name` column to character before replacing `NA`s

### DIFF
--- a/R/dplyr-like.R
+++ b/R/dplyr-like.R
@@ -570,6 +570,7 @@ count_at <- function(.tbl,
                percentage_label_decimal_places = percentage_label_decimal_places,
                add_grouping = add_grouping,
                na.rm = na.rm) %>%
+      mutate(!!var_name := as.character(.data[[var_name]])) %>%
       replace_na(na_replacement_list)
   }) %>%
     mutate(!!long_label_column_names[[1]] := map_chr(.vars, quo_name)[first_which_non_na_at(., !!!.vars)],


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize vctrs, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package broke. An easy way to see this is by installing the PR mentioned above and running:

``` r
library(dplyr)
library(tidytidbits)

mtcars %>% count_at(vars(gear, cyl))
#> Warning: The `add` argument of `group_by()` is deprecated as of dplyr 1.0.0.
#> Please use the `.add` argument instead.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated.
#> Error: Can't convert `replace$gear` <character> to match type of `data$gear` <double>.
```

The problem boils down to the fact that you are calling `replace_na()` on numeric columns, but your replacement is a character string (`"missing"`). This is no longer allowed. It seems like you wanted the end result to be a character vector anyways, so this PR preemptively changes the `!!var_name` column to a character before applying `replace_na()`.

We would greatly appreciate if you could merge this PR and submit a patch release of your package to CRAN so we can send tidyr in!